### PR TITLE
Apply IntelliJ themes to pretty printed code in Forum

### DIFF
--- a/sass/_theme_dark.scss
+++ b/sass/_theme_dark.scss
@@ -58,6 +58,7 @@ $scrollbar-drag-hover-bg: $accent7;
 
   .com { // comment
     color: #629755;
+    font-style: italic;
   }
 
   .pln { // plain

--- a/sass/_theme_dark.scss
+++ b/sass/_theme_dark.scss
@@ -32,20 +32,51 @@ $scrollbar-drag-bg: #222425;
 $scrollbar-drag-hover-bg: $accent7;
 
 .prettyprint {
-  .lit {
-    color: #cdcf1b;
+  background-color: #2b2b2b;
+  color: #a9b7c6;
+
+  .lit { // literal
+    color: #6897bb;
   }
 
-  .kwd {
+  .kwd { // keyword
     font-weight: bold;
-    color: #ea8b3e;
+    color: #cc7832;
   }
 
-  .pun {
-    color: #e3bc5b;
+  .typ { // type
+    color: #4e807d;
   }
 
-  .com {
-    color: #888888;
+  .str { // string
+    color: #6a8759;
+  }
+
+  .pun { // punctuation
+    color: #e8bf6a;
+  }
+
+  .com { // comment
+    color: #629755;
+  }
+
+  .pln { // plain
+    color: #a9b7c6;
+  }
+
+  .dec { // declaration
+    color: #e8bf6a;
+  }
+
+  .tag { // html tag
+    color: #e8bf6a;
+  }
+
+  .atn { // html attribute name
+    color: #a9b7c6;
+  }
+
+  .atv { // html attribute value
+    color: #a5c261;
   }
 }

--- a/sass/_theme_light.scss
+++ b/sass/_theme_light.scss
@@ -32,20 +32,52 @@ $scrollbar-drag-bg: darken($section-bg, 30%);
 $scrollbar-drag-hover-bg: $accent7;
 
 .prettyprint {
-  .lit {
-    color: #008040;
+  background-color: #ffffff;
+  color: #000000;
+
+  .lit { // literal
+    color: #0000ff;
   }
 
-  .kwd {
+  .kwd { // keyword
     font-weight: bold;
-    color: $accent5;
+    color: #000080;
   }
 
-  .pun {
-    color: #800000;
+  .typ { // type
+    color: #20999d;
   }
 
-  .com {
-    color: #888888;
+  .str { // string
+    color: #008000;
+  }
+
+  .pun { // punctuation
+    color: #000000;
+  }
+
+  .com { // comment
+    color: #808080;
+    font-style: italic;
+  }
+
+  .pln { // plain
+    color: #000000;
+  }
+
+  .dec { // declaration
+    color: #000080;
+  }
+
+  .tag { // html tag
+    color: #000080;
+  }
+
+  .atn { // html attribute name
+    color: #0000ff;
+  }
+
+  .atv { // html attribute value
+    color: #008000;
   }
 }


### PR DESCRIPTION
This Pull Request applies the IntelliJ default code highlighting themes to the code highlighting in the Forum.  
As it currently is, the highlighting makes code embedded into posts very hard to read.  
I chose to replace the current color scheme with that of IntelliJ, because it will increase consistency across different posts, between natively embedded code (via the text editor) and code that has been pasted. This is under the assumption that most forum users also use IntelliJ for development. From my observation that seems to be the case.  
Below you will find a comparasion between the old and the new styles.  

Current Native Light:  
![image](https://user-images.githubusercontent.com/3575167/74689178-7b34ce00-51da-11ea-9848-21627161ca78.png)

Current Native Dark:  
![image](https://user-images.githubusercontent.com/3575167/74689209-9dc6e700-51da-11ea-8a6c-08cba333a665.png)

Updated Native Light:  
![image](https://user-images.githubusercontent.com/3575167/74689382-352c3a00-51db-11ea-9cc3-142d3aa54586.png)

Updated Native Dark:  
![image](https://user-images.githubusercontent.com/3575167/74689301-eed6db00-51da-11ea-9f1c-831557786c37.png)

IntelliJ Pastes for comparasion:  
![image](https://user-images.githubusercontent.com/3575167/74689407-52610880-51db-11ea-8a53-d6d6180e63b5.png)

![image](https://user-images.githubusercontent.com/3575167/74689418-6147bb00-51db-11ea-8b59-d8f54972b622.png)

I have used the language `scala` in the screenshots, because it allows for xml literals to be embedded inside it's code, which greatly reduced the number of screenshots I had to make, aswell as their size.

PS: It would be great to know what the script that does the highlighting is called / where to find it, because further improvements could be made by modifying it.