### PR TITLE
Fix forum dark mode?

### DIFF
--- a/sass/_forums.scss
+++ b/sass/_forums.scss
@@ -137,6 +137,13 @@ iframe[data-embedContent] {
   background: none;
 }
 
+// Fix ugly text in dark mode
+#ipsLayout_footer p {
+    color: $body-color;
+}
+
+
+
 // Editor fixes
 .cke_top {
   background: #f9f9f9 !important;
@@ -154,6 +161,11 @@ iframe[data-embedContent] {
 .ipsBox, .ipsWidget.ipsWidget_vertical {
   @extend section;
 }
+// Inner boxes of widgets don't have the sections applied, but they have an ugly color
+.ipsWidget.ipsWidget_vertical .ipsWidget_inner {
+    color: $body-color;
+}
+
 
 // Very specific hacks for headlines in boxes
 .ipsBox:not(.cProfileSidebarBlock):not(.cTopicPostArea), .ipsWidget.ipsWidget_vertical {


### PR DESCRIPTION
As showcased here: ![user stats](https://media.discordapp.net/attachments/313125603924639766/726271229539123230/unknown.png)
and here: ![footer](https://cdn.discordapp.com/attachments/756209390620508321/799755487808585748/unknown.png)

The dark theme of the forums is.. at best, hard to read sometimes.
It looks like the Invision IPS is hardcoded for light theme, and it's annoying as ass.

I'm going to update this until i can track down most of the causes of these.

Note: I have no idea how to apply these styles to a test site, so testing is going to take a while.