### PR TITLE
Change half star icon for latest to outlined half star

### DIFF
--- a/sass/_downloads.scss
+++ b/sass/_downloads.scss
@@ -308,7 +308,7 @@
 }
 
 .promo-latest:before {
-  content: "\f123"; // Half Star (outlined): fa-star-o
+  content: "\f123"; // Half Star (outlined): fa-star-half-o
 }
 
 .promo-recommended:before {

--- a/sass/_downloads.scss
+++ b/sass/_downloads.scss
@@ -308,7 +308,7 @@
 }
 
 .promo-latest:before {
-  content: "\f089"; // Half Star: fa-star-half
+  content: "\f123"; // Half Star (outlined): fa-star-o
 }
 
 .promo-recommended:before {


### PR DESCRIPTION
This PR changes the current half star icon (`fa-half-star`) for the latest version on the downloads site (as implemented by 0f187f13240c51d7b9901342fc12a71974bf675d) to the outlined half star (`fa-half-star-o`). This looks a bit better because it has the same width as the full star (as seen below), and prevents possible confusion from people which may think that the icon is bugged somehow because it's only half of a star.

---

### Before 
![Image of the downloads for Minecraft 1.16.5, with the non-outlined half star](https://user-images.githubusercontent.com/21304337/133896990-745d4016-5307-4868-bfe8-944994bffe0a.png)

---

### After (this PR)
![Image of the downloads for Minecraft 1.16.5, with the outlined half star as changed by this PR](https://user-images.githubusercontent.com/21304337/133896999-ccc761f9-7435-4fc4-b786-2da5247eaeda.png)

---
