### PR TITLE
Reduce content jumping during top ad load

### DIFF
--- a/sass/_downloads.scss
+++ b/sass/_downloads.scss
@@ -321,6 +321,7 @@
 
 .promo-downloads-top, .ad-downloads-top {
   margin-bottom: 2rem !important;
+  min-height: 121px; // significantly reduce the top ad making the rest of the page jump about during page load
 }
 
 .promo-downloads-bottom, .ad-downloads-bottom {


### PR DESCRIPTION
Simple one-liner - sets the minimum height of the top ad container to the known usual max height it can be, so that it won't push around the stuff below it as much during page load.