### PR TITLE
Replace Stickyfill with native CSS sticky

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -343,7 +343,6 @@
         src="//cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
 <script type="text/javascript"
         src="//cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/stickyfill/1.1.4/stickyfill.min.js"></script>
 <script type="text/javascript"
         src="//cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
 <script type="text/javascript" src="/static/js/merged-google.js"></script>

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -2,7 +2,6 @@
  Implementation for sidebars used on the Forge sites.
  */
 $(document).ready(function () {
-    $('.sidebar-sticky').Stickyfill();
     $('.scroll-pane').jScrollPane({
         autoReinitialise: true,
         verticalGutter: 0,

--- a/sass/_privacy.scss
+++ b/sass/_privacy.scss
@@ -4,6 +4,7 @@
 
 // Bar under the navigation for privacy disclaimer
 .privacy-disclaimer {
+  position: -webkit-sticky;
   position: sticky;
   display: none;
   top: 0;

--- a/sass/_sidebars.scss
+++ b/sass/_sidebars.scss
@@ -17,6 +17,7 @@
   }
 
   .sidebar-sticky {
+    position: -webkit-sticky;
     position: sticky;
     top: 1rem;
   }

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -15,7 +15,6 @@
 <script type="text/javascript" src="https://use.fontawesome.com/a1f20be65b.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stickyfill/1.1.4/stickyfill.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
 {%- if md.global_config['enable_adsense'] %}
     <script type="text/javascript" src="{{ static_root }}js/merged-google.js?{{ now.timestamp() }}"></script>


### PR DESCRIPTION
Speeds up page load for virtually all users at the cost of a worse (but still usable) layout for the remaining ≤0.2% of IE users (according to Google Analytics browser stats provided in the Forge Discord server)