### PR TITLE
Remove the unused jQuery Mouse Wheel plugin

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -340,8 +340,6 @@
 </div>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script type="text/javascript"
-        src="//cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
-<script type="text/javascript"
         src="//cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/stickyfill/1.1.4/stickyfill.min.js"></script>
 <script type="text/javascript"

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -13,7 +13,6 @@
 </div>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script type="text/javascript" src="https://use.fontawesome.com/a1f20be65b.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stickyfill/1.1.4/stickyfill.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>


### PR DESCRIPTION
It adds the `$('#my_elem').on('mousewheel', function(event) {` and `$('#my_elem').mousewheel(function(event) {` APIs, but they're not used anywhere - only the <script> tags are here.

Any future mousewheel JS API needs should use the native WheelEvent API that works in IE9+: https://caniuse.com/mdn-api_wheelevent