### PR TITLE
Split JS files and optimise Gradle build

### DIFF
--- a/Instructions.md
+++ b/Instructions.md
@@ -48,7 +48,6 @@ Firstly, we need to setup the Python side:
 
 Now, let's setup the Gradle side:
 1. Import the `build.gradle` into your IDE
-    - Due to the old Gradle 5.6.4 in use here, you'll need to use Java 8 for it to work
 2. Run `gradlew setupTest`
 
 ## Step 2: Run PageGen

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ tasks.register("css", io.freefair.gradle.plugins.jsass.SassCompile) {
 }
 
 void createJsTask(final String taskName, final String fileName) {
-    tasks.register("minify${taskName.capitalize()}Js", com.eriwen.gradle.js.tasks.MinifyJsTask) {
+    tasks.register("minify${taskName.capitalize()}DotJs", com.eriwen.gradle.js.tasks.MinifyJsTask) {
         source = file("${projectDir}/js/${fileName}.js")
         dest = file("${buildDir}/js/${fileName}.min.js")
     }
@@ -24,7 +24,7 @@ createJsTask('sidebar', "sidebar")
 createJsTask('files', "files")
 
 tasks.register("minifyJsFiles") {
-    it.dependsOn("minifyThemeSwitchJs", "minifyThemeSwitchToggleJs", "minifyCurseAdsJs", "minifySidebarJs", "minifyFilesJs")
+    it.dependsOn("minifyThemeSwitchDotJs", "minifyThemeSwitchToggleDotJs", "minifyCurseAdsDotJs", "minifySidebarDotJs", "minifyFilesDotJs")
 }
 
 tasks.register("bundleFiles", Zip) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,57 +3,38 @@ plugins {
     id "com.magnetichq.gradle.js" version "3.0.2"
 }
 
-task css(type: io.freefair.gradle.plugins.jsass.SassCompile) {
+tasks.register("css", io.freefair.gradle.plugins.jsass.SassCompile) {
     sassPath = "${projectDir}/sass"
     cssPath = "${buildDir}/css"
     sourceMapEnabled = false
     outputStyle = io.bit3.jsass.OutputStyle.COMPRESSED
 }
 
-def createJsTask(String name, files) {
-    def combineTask = tasks.register("combine${name.capitalize()}Js", com.eriwen.gradle.js.tasks.CombineJsTask) {
-        source = files
-        dest = file("${buildDir}/js/${name}.js")
-    }
-    def minifyTask = tasks.register("minify${name.capitalize()}Js", com.eriwen.gradle.js.tasks.MinifyJsTask) {
-        source = combineTask
-        dest = file("${buildDir}/js/${name}.js")
+void createJsTask(final String taskName, final String fileName) {
+    tasks.register("minify${taskName.capitalize()}Js", com.eriwen.gradle.js.tasks.MinifyJsTask) {
+        source = file("${projectDir}/js/${fileName}.js")
+        dest = file("${buildDir}/js/${fileName}.min.js")
+        outputStyle
     }
 }
 
-createJsTask('filesCurse', [
-    "${projectDir}/js/sidebar.js",
-    "${projectDir}/js/theme-switch-toggle.js",
-    "${projectDir}/js/curse-ads.js",
-    "${projectDir}/js/files.js"
-])
-createJsTask('filesGoogle', [
-    "${projectDir}/js/sidebar.js",
-    "${projectDir}/js/theme-switch-toggle.js",
-    "${projectDir}/js/google-ads.js",
-    "${projectDir}/js/files.js"
-])
-createJsTask('docs', [
-    "${projectDir}/js/sidebar.js",
-    "${projectDir}/js/theme-switch-toggle.js",
-    "${projectDir}/js/docs.js"
-])
-createJsTask('themeSwitch', ["${projectDir}/js/theme-switch.js"])
+createJsTask('themeSwitch', "theme-switch")
+createJsTask('themeSwitchToggle', "theme-switch-toggle")
+createJsTask('curseAds', "curse-ads")
+createJsTask('sidebar', "sidebar")
+createJsTask('files', "files")
 
-task bundleFiles(type: Zip) {
+tasks.register("minifyJsFiles") {
+    it.dependsOn("minifyThemeSwitchJs", "minifyThemeSwitchToggleJs", "minifyCurseAdsJs", "minifySidebarJs", "minifyFilesJs")
+}
+
+tasks.register("bundleFiles", Zip) {
+    dependsOn minifyJsFiles
     archiveBaseName = 'files-bundle'
     destinationDirectory = file("${buildDir}/distributions")
-    from(minifyFilesCurseJs) {
+    from(file("${buildDir}/js")) {
+        include '*.js'
         into 'static/js'
-        rename ~/filesCurse/, 'merged-curse'
-    }
-    from(minifyFilesGoogleJs) {
-        into 'static/js'
-        rename ~/filesGoogle/, 'merged-google'
-    }
-    from(minifyThemeSwitchJs) {
-        into 'static/js'
-        rename ~/themeSwitch/, 'theme-switch'
     }
     from(css) {
         include 'website_*.css'
@@ -79,7 +60,7 @@ static String digest(String data, String hash) {
     return java.security.MessageDigest.getInstance(hash).digest(data.bytes).encodeHex().toString()
 }
 
-def writeArtifact(group, name, version, classifier = null, String ext = 'jar') {
+void writeArtifact(group, name, version, classifier = null, String ext = 'jar') {
     String path = "${group}/${name}/${version}/${name}-${version}"
     if (classifier != null)
         path += '-' + classifier
@@ -91,10 +72,10 @@ def writeArtifact(group, name, version, classifier = null, String ext = 'jar') {
     file("./test/maven/${path}.sha256").text = digest(path, 'SHA-256')
 }
 
-def writeXml(String group, String name, vers) {
+void writeXml(String group, String name, List vers) {
     def writer = new StringWriter()
     def xml = new groovy.xml.MarkupBuilder(writer)
-    def path = "./test/maven/${group}/${name}"
+    String path = "./test/maven/${group}/${name}"
     
     xml.metadata() {
         groupId(group.replace('/', '.'))
@@ -133,11 +114,11 @@ def writeXml(String group, String name, vers) {
     ]).toPrettyString()
 }
 
-task deleteTestData(type: Delete) {
+tasks.register("deleteTestData", Delete) {
     delete './test/'
 }
 
-task generateMaven() {
+tasks.register('generateMaven') {
     mustRunAfter deleteTestData
     doLast {
         List versions = []
@@ -159,7 +140,7 @@ task generateMaven() {
     }
 }
 
-task generateGlobalConfig() {
+tasks.register('generateGlobalConfig') {
     mustRunAfter deleteTestData
     doLast {
         def file = file('./test/global_overrides.json')
@@ -172,13 +153,14 @@ task generateGlobalConfig() {
     }
 }
 
-task extractBundledFiles(type: Copy, dependsOn: bundleFiles) {
+tasks.register('extractBundledFiles', Copy) {
+    dependsOn bundleFiles
     mustRunAfter deleteTestData
     from zipTree(bundleFiles.archiveFile)
     into file('./test/')
 }
 
-task runTestPageGen(type: Exec) {
+tasks.register('runTestPageGen', Exec) {
     String os = System.getProperty('os.name').toLowerCase(Locale.ROOT)
     if (os.contains('win'))
         commandLine 'powershell', '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Unrestricted', './runTestPageGen.ps1'
@@ -186,7 +168,7 @@ task runTestPageGen(type: Exec) {
         commandLine 'sh', './runTestPageGen.sh'
 }
 
-task setupPageGen(type: Exec) {
+tasks.register('setupPageGen', Exec) {
     String os = System.getProperty('os.name').toLowerCase(Locale.ROOT)
     if (os.contains('win'))
         commandLine 'powershell', '-NoLogo', '-NoProfile', '-Command', 'pip install -r requirements.txt'
@@ -194,6 +176,7 @@ task setupPageGen(type: Exec) {
         commandLine 'sh', '-c', 'pip install -r requirements.txt'
 }
 
-task setupTest(dependsOn: [deleteTestData, extractBundledFiles, generateMaven, generateGlobalConfig, setupPageGen]) {
+tasks.register('setupTest') {
+    dependsOn = [deleteTestData, extractBundledFiles, generateMaven, generateGlobalConfig, setupPageGen]
     doLast { file('./test/out').mkdirs() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,22 +10,22 @@ tasks.register("css", io.freefair.gradle.plugins.jsass.SassCompile) {
     outputStyle = io.bit3.jsass.OutputStyle.COMPRESSED
 }
 
+def minifyJsFiles = tasks.register("minifyJsFiles")
+
 void createJsTask(final String taskName, final String fileName) {
-    tasks.register("minify${taskName.capitalize()}DotJs", com.eriwen.gradle.js.tasks.MinifyJsTask) {
+    def tmp = tasks.register("minify${taskName.capitalize()}DotJs", com.eriwen.gradle.js.tasks.MinifyJsTask) {
         source = file("${projectDir}/js/${fileName}.js")
         dest = file("${buildDir}/js/${fileName}.min.js")
     }
+    minifyJsFiles.dependsOn(tmp)
 }
 
 createJsTask('themeSwitch', "theme-switch")
 createJsTask('themeSwitchToggle', "theme-switch-toggle")
 createJsTask('curseAds', "curse-ads")
+createJsTask('googleAds', "google-ads")
 createJsTask('sidebar', "sidebar")
-createJsTask('files', "files")
-
-tasks.register("minifyJsFiles") {
-    it.dependsOn("minifyThemeSwitchDotJs", "minifyThemeSwitchToggleDotJs", "minifyCurseAdsDotJs", "minifySidebarDotJs", "minifyFilesDotJs")
-}
+createJsTask('files', "files
 
 tasks.register("bundleFiles", Zip) {
     dependsOn minifyJsFiles

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ void writeArtifact(group, name, version, classifier = null, String ext = 'jar') 
 }
 
 void writeXml(String group, String name, List vers) {
-    def writer = new StringWriter()
+    final writer = new StringWriter()
     def xml = new groovy.xml.MarkupBuilder(writer)
     String path = "./test/maven/${group}/${name}"
     
@@ -102,7 +102,7 @@ void writeXml(String group, String name, List vers) {
             adfocus: "271228"
     ]).toPrettyString()
     file("${path}/promotions_slim.json").text = new groovy.json.JsonBuilder([
-        homepage: 'https://not_real/',
+        homepage: 'https://not_real.invalid/',
         promos: [
             '1.16.5-latest':      '36.1.2',
             '1.16.5-recommended': '36.1.2',

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ void createJsTask(final String taskName, final String fileName) {
     tasks.register("minify${taskName.capitalize()}Js", com.eriwen.gradle.js.tasks.MinifyJsTask) {
         source = file("${projectDir}/js/${fileName}.js")
         dest = file("${buildDir}/js/${fileName}.min.js")
-        outputStyle
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/python/templates.py
+++ b/python/templates.py
@@ -37,7 +37,9 @@ class Templates:
         self.env.globals['static_root'] = static_base
         self.env.globals['web_base'] = web_base
         self.env.globals['repository_base'] = repository_base
-        self.env.globals['now'] = datetime.datetime.utcnow()
+        now = datetime.datetime.utcnow()
+        self.env.globals['now'] = now
+        self.env.globals['currentYearAndWeek'] = str(now.year) + str(now.isocalendar().week)
         self.env.globals['show_classifier'] = show_classifier
         self.env.globals['get_artifact_description'] = get_artifact_description
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==2.11.3
-Markdown==3.3.4
+Markdown==3.3.7
 MarkupSafe==1.1.1
-requests~=2.25.1
+requests~=2.28.1

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -11,10 +11,10 @@
         </div>
     </footer>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" crossorigin="anonymous"></script>
 <script src="https://use.fontawesome.com/a1f20be65b.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js" crossorigin="anonymous"></script>
 <script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ now.timestamp() }}"></script>
 <script src="{{ static_root }}js/curse-ads.min.js?{{ now.timestamp() }}"></script>
 <script src="{{ static_root }}js/sidebar.min.js?{{ now.timestamp() }}"></script>

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -15,10 +15,10 @@
 <script src="https://use.fontawesome.com/a1f20be65b.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js" crossorigin="anonymous"></script>
-<script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ currentYearAndWeek }}"></script>
-<script src="{{ static_root }}js/curse-ads.min.js?{{ currentYearAndWeek }}"></script>
-<script src="{{ static_root }}js/sidebar.min.js?{{ currentYearAndWeek }}"></script>
-<script src="{{ static_root }}js/files.min.js?{{ currentYearAndWeek }}"></script>
+<script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ crc32(static_root + 'js/theme-switch-toggle.min.js') }}"></script>
+<script src="{{ static_root }}js/curse-ads.min.js?{{ crc32(static_root + 'js/curse-ads.min.js') }}"></script>
+<script src="{{ static_root }}js/sidebar.min.js?{{ crc32(static_root + 'js/sidebar.min.js') }}"></script>
+<script src="{{ static_root }}js/files.min.js?{{ crc32(static_root + 'js/files.min.js') }}"></script>
 {% if artifact and artifact.config['analytics'] %}{{ artifact.config['analytics'] }}{% endif %}
 
 {%- if artifact and artifact.config['body_end'] %}

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -15,10 +15,10 @@
 <script src="https://use.fontawesome.com/a1f20be65b.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js" crossorigin="anonymous"></script>
-<script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ now.timestamp() }}"></script>
-<script src="{{ static_root }}js/curse-ads.min.js?1"></script> <!-- manually increment the ?1 when you change the file -->
-<script src="{{ static_root }}js/sidebar.min.js?1"></script>
-<script src="{{ static_root }}js/files.min.js?1"></script>
+<script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ currentYearAndWeek }}"></script>
+<script src="{{ static_root }}js/curse-ads.min.js?{{ currentYearAndWeek }}"></script>
+<script src="{{ static_root }}js/sidebar.min.js?{{ currentYearAndWeek }}"></script>
+<script src="{{ static_root }}js/files.min.js?{{ currentYearAndWeek }}"></script>
 {% if artifact and artifact.config['analytics'] %}{{ artifact.config['analytics'] }}{% endif %}
 
 {%- if artifact and artifact.config['body_end'] %}

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -11,15 +11,14 @@
         </div>
     </footer>
 </div>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-<script type="text/javascript" src="https://use.fontawesome.com/a1f20be65b.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
-{%- if md.global_config['enable_adsense'] %}
-    <script type="text/javascript" src="{{ static_root }}js/merged-google.js?{{ now.timestamp() }}"></script>
-{%- else %}
-    <script type="text/javascript" src="{{ static_root }}js/merged-curse.js?{{ now.timestamp() }}"></script>
-{%- endif %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+<script src="https://use.fontawesome.com/a1f20be65b.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
+<script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ now.timestamp() }}"></script>
+<script src="{{ static_root }}js/curse-ads.min.js?{{ now.timestamp() }}"></script>
+<script src="{{ static_root }}js/sidebar.min.js?{{ now.timestamp() }}"></script>
+<script src="{{ static_root }}js/files.min.js?{{ now.timestamp() }}"></script>
 {% if artifact and artifact.config['analytics'] %}{{ artifact.config['analytics'] }}{% endif %}
 
 {%- if artifact and artifact.config['body_end'] %}

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -16,7 +16,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
 <script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ crc32(static_root + 'js/theme-switch-toggle.min.js') }}"></script>
+{%- if md.global_config['enable_adsense'] %}
+<script src="{{ static_root }}js/google-ads.min.js?{{ crc32(static_root + 'js/google-ads.min.js') }}"></script>
+{%- else %}
 <script src="{{ static_root }}js/curse-ads.min.js?{{ crc32(static_root + 'js/curse-ads.min.js') }}"></script>
+{%- endif %}
 <script src="{{ static_root }}js/sidebar.min.js?{{ crc32(static_root + 'js/sidebar.min.js') }}"></script>
 <script src="{{ static_root }}js/files.min.js?{{ crc32(static_root + 'js/files.min.js') }}"></script>
 {% if artifact and artifact.config['analytics'] %}{{ artifact.config['analytics'] }}{% endif %}

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -11,10 +11,10 @@
         </div>
     </footer>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
 <script src="https://use.fontawesome.com/a1f20be65b.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js"></script>
 <script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ crc32(static_root + 'js/theme-switch-toggle.min.js') }}"></script>
 <script src="{{ static_root }}js/curse-ads.min.js?{{ crc32(static_root + 'js/curse-ads.min.js') }}"></script>
 <script src="{{ static_root }}js/sidebar.min.js?{{ crc32(static_root + 'js/sidebar.min.js') }}"></script>

--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -16,9 +16,9 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tooltipster/3.3.0/js/jquery.tooltipster.min.js" crossorigin="anonymous"></script>
 <script src="{{ static_root }}js/theme-switch-toggle.min.js?{{ now.timestamp() }}"></script>
-<script src="{{ static_root }}js/curse-ads.min.js?{{ now.timestamp() }}"></script>
-<script src="{{ static_root }}js/sidebar.min.js?{{ now.timestamp() }}"></script>
-<script src="{{ static_root }}js/files.min.js?{{ now.timestamp() }}"></script>
+<script src="{{ static_root }}js/curse-ads.min.js?1"></script> <!-- manually increment the ?1 when you change the file -->
+<script src="{{ static_root }}js/sidebar.min.js?1"></script>
+<script src="{{ static_root }}js/files.min.js?1"></script>
 {% if artifact and artifact.config['analytics'] %}{{ artifact.config['analytics'] }}{% endif %}
 
 {%- if artifact and artifact.config['body_end'] %}

--- a/templates/page_header.html
+++ b/templates/page_header.html
@@ -41,7 +41,7 @@
     <link rel="stylesheet" data-theme="dark" href="{{ static_root }}css/styles_dark.css?{{ crc32(static_root + 'css/styles_dark.css') }}">
     <script src="{{ static_root }}js/theme-switch.min.js?{{ crc32(static_root + 'js/theme-switch.min.js') }}"></script>
     <!-- relative time in browser -->
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/combine/npm/dayjs@1.10.4,npm/dayjs@1.10.4/plugin/relativeTime.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/combine/npm/dayjs@1.10.8,npm/dayjs@1.10.8/plugin/relativeTime.min.js"></script>
     <script>dayjs.extend(dayjs_plugin_relativeTime)</script>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/templates/page_header.html
+++ b/templates/page_header.html
@@ -37,9 +37,9 @@
 
     <link type="text/css" rel="stylesheet" href="{{ static_root }}css/tooltipster.css">
     <link type="text/css" rel="stylesheet" href="{{ static_root }}css/tooltipster-shadow.css">
-    <link type="text/css" rel="stylesheet" data-theme="light" href="{{ static_root }}css/styles_light.css?{{ now.timestamp() }}">
-    <link type="text/css" rel="stylesheet" data-theme="dark" href="{{ static_root }}css/styles_dark.css?{{ now.timestamp() }}">
-    <script type="text/javascript" src="{{ static_root }}js/theme-switch.js?{{ now.timestamp() }}"></script>
+    <link rel="stylesheet" data-theme="light" href="{{ static_root }}css/styles_light.css?{{ crc32(static_root + 'css/styles_light.css') }}">
+    <link rel="stylesheet" data-theme="dark" href="{{ static_root }}css/styles_dark.css?{{ crc32(static_root + 'css/styles_dark.css') }}">
+    <script src="{{ static_root }}js/theme-switch.min.js?{{ crc32(static_root + 'js/theme-switch.min.js') }}"></script>
     <!-- relative time in browser -->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/combine/npm/dayjs@1.10.4,npm/dayjs@1.10.4/plugin/relativeTime.min.js"></script>
     <script>dayjs.extend(dayjs_plugin_relativeTime)</script>


### PR DESCRIPTION
# Summary
- Split up JS to help simplify the move to a future full-Groovy system and allow for async JS optimisations later on 
- Used [Gradle's Task Configuration Avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) to speed up builds
- Changed jQuery link to a non-Google one that should work in China
- Use CRC32 checksums for cache busting instead of the time of the generated page

# Details and rationale

## Split JS files
JS files used to be merged because at the time, SPDY and HTTP/2 weren't commonplace and merging files to reduce sequential requests tends to reduce overhead and improve performance on HTTP/1.

This is no longer necessary in HTTP/2 (file downloads are multiplexed, so head-of-line blocking is no longer an issue that needs manual workarounds like merging) and causes all our JS files to be redownloaded in full if a change is made to any single file, which hurts cache hit rates.

Splitting up the JS will simplify the move to a future full-Groovy build system and make more optimisations possible later on (such as having different JS files download and execute asynchronously).

### jQuery URL change
After seeing #24, I thought it would make sense to change the jQuery URL to a non-Google one so that it can be accessed in China, resulting in a less broken site for them.

### CRC32 checksum cache busting
Currently the files site uses the timestamp of when the page was generated for the JS files, even if they haven't changed. This forces the browser to redownload these files every time a new version is released.

This has been changed for a CRC32 checksum system that does not change if the file remains the same.

## Optimise Gradle build
All task definitions have been changed to use [Gradle's Task Configuration Avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) to speed up builds. The Gradle part of the build system is now noticeably faster for the "configuring tasks" stage as it no longer needs to eagerly create any tasks at configuration time.

I've also explicitly typed a few more things here and there to speed up the "compile Groovy buildscript" stage slightly.

# Benchmarks

## Gradle
Deleted the `.gradle` and `build` folders, then ran `gradlew --scan bundleFiles`

Before: https://scans.gradle.com/s/is6p2xlruxak4/performance/configuration
After: https://scans.gradle.com/s/wkuvdn6w3rzxw/performance/configuration

| Metric | Before | After |
|--------|---------|-------|
| # of tasks created immediately | 17 | 8 |
| Model configuration | 2.9s | 0.4s |
| Task graph configuration | 0.1s | 0.003s |
| Total configuration time | 4.6s | 0.4s |

## Site
`gradlew setupTest` then `gradlew runTestPageGen`, copied over each test build over to its own folder and fixed file links as necessary. F12 network tab simulating fast 3G with cache disabled. Tested twice - once with XAMPP (HTTP/1) and once with [simplehttp2server](https://github.com/GoogleChromeLabs/simplehttp2server) (HTTP/2)

For HTTP/1, page load was about 0.5-1s slower on avg.
For HTTP/2, it was within margin of error for an uncached page load.

The performance benefit becomes a bit more apparent when a script is changed. For example, if  `files.js`  is changed it'll now only redownload that one file rather than the entire merged js. More performance gains are now possible with some changes to the JS, allowing different scripts to be loaded async in the future.

Considering that the aim of this PR wasn't to improve page load times on its own (but instead to help simplify the move to newer things and allow for optimisations in future PRs), it's good to know that performance at least isn't any worse over HTTP/2.
