### PR TITLE
Add uptime status link to the footer

### DIFF
--- a/templates/page_footer.html
+++ b/templates/page_footer.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
     <footer>
-        Copyright © 2018-{{ now.year }} by Forge Development LLC &middot; Ads by Longitude Ads LLC &middot; <a href="{{ static_root }}privacy.html">Privacy Information</a> {%- if md.global_config['ad_footer'] %}{{ md.global_config['ad_footer'] }}{%- endif %}<br>
+        Copyright © 2018-{{ now.year }} by Forge Development LLC &middot; Ads by Longitude Ads LLC &middot; <a href="https://status.minecraftforge.net">Status</a> &middot; <a href="{{ static_root }}privacy.html">Privacy Information</a> {%- if md.global_config['ad_footer'] %}{{ md.global_config['ad_footer'] }}{%- endif %}<br>
         Layout is designed by and used with permission from PaleoCrafter
         <div class="theme-switch-wrapper">
             Enable Dark Theme


### PR DESCRIPTION
Looks like this and points to https://status.minecraftforge.net
![image](https://user-images.githubusercontent.com/3158390/174441919-3900ad6c-a66a-4d8f-8f1d-0d52586e4e71.png)