### PR TITLE
Drop IE8 support

### DIFF
--- a/templates/page_header.html
+++ b/templates/page_header.html
@@ -43,13 +43,6 @@
     <!-- relative time in browser -->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/combine/npm/dayjs@1.10.4,npm/dayjs@1.10.4/plugin/relativeTime.min.js"></script>
     <script>dayjs.extend(dayjs_plugin_relativeTime)</script>
-
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
 </head>
 <body>
 {%- if artifact and artifact.config['body_start'] %}


### PR DESCRIPTION
Less than a fraction of a percent of visitors use IE8 or lower, who already see a very broken page. Removing code for this slightly reduces bandwidth usage without significantly changing the layout or functionality for IE8 users.