### PR TITLE
Default to latest MC instead of the last one with an RB

### DIFF
--- a/python/metadata.py
+++ b/python/metadata.py
@@ -188,7 +188,7 @@ class Artifact:
                 if release_mc_version not in release_mc_versions:
                     release_mc_versions[release_mc_version] = []
                 release_mc_versions[release_mc_version].append(mc_version)
-            first_idx = next((mc for mc in sorted_mc_versions if 'recommended' in self.promotions.get(mc, [])), sorted_mc_versions[0])
+            first_idx = next((mc for mc in sorted_mc_versions if 'latest' in self.promotions.get(mc, [])), sorted_mc_versions[0])
             yield 'index.html', global_context | {'mc_version': first_idx, 'release_mc_version': self.get_release_milestone(MCVer(first_idx)), 'mcversions': sorted_mc_versions, 'release_mcversions': release_mc_versions}
             for mc_version in sorted_mc_versions:
                 yield f'index_{mc_version}.html', global_context | {'mc_version': mc_version, 'release_mc_version': self.get_release_milestone(MCVer(mc_version)), 'mcversions': sorted_mc_versions, 'release_mcversions': release_mc_versions, 'canonical_url': '' if mc_version == first_idx else f'index_{mc_version}.html'}


### PR DESCRIPTION
For example, this makes it so that going to https://files.minecraftforge.net shows 1.21.4 by default instead of 1.20.6.